### PR TITLE
Fetch ftxui from conan.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,20 +11,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(FetchContent)
 
-set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
-FetchContent_Declare(ftxui
-  GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
-  GIT_TAG v2.0.0
-)
-
-FetchContent_GetProperties(ftxui)
-if(NOT ftxui_POPULATED)
-  FetchContent_Populate(ftxui)
-  add_subdirectory(${ftxui_SOURCE_DIR} ${ftxui_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
-
-
-
 # Note: by default ENABLE_DEVELOPER_MODE is True
 # This means that all analysis (sanitizers, static analysis)
 # is enabled and all warnings are treated as errors

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -5,6 +5,7 @@ catch2/2.13.8
 docopt.cpp/0.6.3
 #fmt/8.1.1
 spdlog/1.9.2
+ftxui/2.0.0
 
 [generators]
 cmake_find_package_multi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(fmt CONFIG)
 find_package(spdlog CONFIG)
 find_package(docopt CONFIG)
+find_package(ftxui CONFIG)
 
 # Generic test that uses conan libs
 add_executable(intro main.cpp)
@@ -10,13 +11,9 @@ target_link_libraries(
           project_warnings
           docopt::docopt
           fmt::fmt
-          spdlog::spdlog)
-
-target_link_system_libraries(
-  intro
-  PRIVATE
-  ftxui::screen
-  ftxui::dom
-  ftxui::component)
+          spdlog::spdlog
+          ftxui::screen
+          ftxui::dom
+          ftxui::component)
 
 target_include_directories(intro PRIVATE "${CMAKE_BINARY_DIR}/configured_files/include")


### PR DESCRIPTION
Conan is already used to fetch all the other dependencies. Fetching all dependencies in a similar manner (conan) reduces the complexity of using the project.